### PR TITLE
lab1: add minesweeper layout

### DIFF
--- a/KharynaSerhii/index.html
+++ b/KharynaSerhii/index.html
@@ -1,142 +1,140 @@
-<!doctype html>
+```html
+<!DOCTYPE html>
 <html lang="uk">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Статичний інтерфейс гри Сапер для лабораторної роботи з HTML та CSS."
-    />
-    <title>Сапер — Kharyna Serhii</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@600;700&family=Nunito:wght@600;700;800&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body>
-    <main class="game" aria-labelledby="game-title">
-      <header class="game__header">
-        <p class="game__eyebrow">Класична головоломка</p>
-        <h1 id="game-title">Сапер</h1>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minesweeper</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <main class="game">
+        <header class="game-header">
+            <p class="game-eyebrow">Classic puzzle game</p>
+            <h1>Minesweeper</h1>
 
-        <div class="game__controls" aria-label="Панель керування грою">
-          <div class="indicator" aria-label="Залишилося прапорців: 6">
-            <span class="indicator__icon" aria-hidden="true">⚑</span>
-            <span class="indicator__value">006</span>
-            <span class="indicator__label">прапорців</span>
-          </div>
+            <div class="game-controls">
+                <div class="indicator">
+                    <span class="indicator-icon" aria-hidden="true">🚩</span>
+                    <span class="indicator-value">010</span>
+                    <span class="indicator-label">Flags</span>
+                </div>
 
-          <button class="restart-button" type="button" aria-label="Почати нову гру">
-            <span aria-hidden="true">🙂</span>
-            <span class="restart-button__text">Нова гра</span>
-          </button>
+                <button class="restart-button" type="button" aria-label="Start a new game">
+                    <span aria-hidden="true">🙂</span>
+                    <span class="restart-button-text">New game</span>
+                </button>
 
-          <div class="indicator" aria-label="Час гри: 42 секунди">
-            <span class="indicator__icon" aria-hidden="true">◷</span>
-            <span class="indicator__value">042</span>
-            <span class="indicator__label">секунд</span>
-          </div>
-        </div>
-      </header>
+                <div class="indicator">
+                    <span class="indicator-icon" aria-hidden="true">⏱</span>
+                    <span class="indicator-value">000</span>
+                    <span class="indicator-label">Time</span>
+                </div>
+            </div>
+        </header>
 
-      <section class="board-section" aria-label="Ігрове поле Сапера">
-        <p class="board-section__hint">Ліва кнопка — відкрити · Права — поставити прапорець</p>
-        <div class="board" role="grid" aria-label="Ігрове поле 9 на 9 клітинок">
-          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 1, стовпець 1, відкрита, одна міна поруч">1</button>
-          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 1, стовпець 2, відкрита, порожня"></button>
-          <button class="cell cell--opened cell--number-2" type="button" role="gridcell" aria-label="Рядок 1, стовпець 3, відкрита, дві міни поруч">2</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 4, закрита"></button>
-          <button class="cell cell--closed cell--flag cell--flag-on-mine" type="button" role="gridcell" aria-label="Рядок 1, стовпець 5, міна позначена прапорцем">⚑</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 9, закрита"></button>
+        <section class="board-section" aria-label="Minesweeper game board">
+            <p class="board-section-hint">
+                Find all mines without stepping on them.
+            </p>
 
-          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 2, стовпець 1, відкрита, порожня"></button>
-          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 2, стовпець 2, відкрита, одна міна поруч">1</button>
-          <button class="cell cell--opened cell--number-3" type="button" role="gridcell" aria-label="Рядок 2, стовпець 3, відкрита, три міни поруч">3</button>
-          <button class="cell cell--closed cell--flag cell--flag-without-mine" type="button" role="gridcell" aria-label="Рядок 2, стовпець 4, порожня клітинка неправильно позначена прапорцем">⚑</button>
-          <button class="cell cell--mine" type="button" role="gridcell" aria-label="Рядок 2, стовпець 5, міна">✹</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 9, закрита"></button>
+            <div class="board">
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-opened cell-number-1" type="button" aria-label="One mine nearby">1</button>
+                <button class="cell cell-opened cell-number-2" type="button" aria-label="Two mines nearby">2</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 3, стовпець 1, відкрита, порожня"></button>
-          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 3, стовпець 2, відкрита, одна міна поруч">1</button>
-          <button class="cell cell--opened cell--number-2" type="button" role="gridcell" aria-label="Рядок 3, стовпець 3, відкрита, дві міни поруч">2</button>
-          <button class="cell cell--opened cell--number-4" type="button" role="gridcell" aria-label="Рядок 3, стовпець 4, відкрита, чотири міни поруч">4</button>
-          <button class="cell cell--mine cell--mine-hit" type="button" role="gridcell" aria-label="Рядок 3, стовпець 5, підірвана міна">✹</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 7, закрита"></button>
-          <button class="cell cell--closed cell--flag" type="button" role="gridcell" aria-label="Рядок 3, стовпець 8, позначена прапорцем">⚑</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-opened cell-number-1" type="button" aria-label="One mine nearby">1</button>
+                <button class="cell cell-opened cell-number-3" type="button" aria-label="Three mines nearby">3</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 3, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 4, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-flag" type="button" aria-label="Flagged cell">🚩</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-opened cell-number-1" type="button" aria-label="One mine nearby">1</button>
+                <button class="cell cell-opened cell-number-3" type="button" aria-label="Three mines nearby">3</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 3, закрита"></button>
-          <button class="cell cell--closed cell--flag" type="button" role="gridcell" aria-label="Рядок 5, стовпець 4, позначена прапорцем">⚑</button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-opened cell-number-1" type="button" aria-label="One mine nearby">1</button>
+                <button class="cell cell-mine-hit" type="button" aria-label="Mine hit">💣</button>
+                <button class="cell cell-opened" type="button" aria-label="Empty cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-flag" type="button" aria-label="Flagged cell">🚩</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 3, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 4, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-opened cell-number-2" type="button" aria-label="Two mines nearby">2</button>
+                <button class="cell cell-opened cell-number-3" type="button" aria-label="Three mines nearby">3</button>
+                <button class="cell cell-opened" type="button" aria-label="Empty cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 3, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 4, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-mine" type="button" aria-label="Mine">💣</button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 3, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 4, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 9, закрита"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
 
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 1, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 2, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 3, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 4, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 5, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 6, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 7, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 8, закрита"></button>
-          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 9, закрита"></button>
-        </div>
-        <p class="game-message" role="status" aria-live="polite">Гра триває. Знайдіть усі міни!</p>
-      </section>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+                <button class="cell cell-closed" type="button" aria-label="Closed cell"></button>
+            </div>
+
+            <p class="game-message">
+                Static preview of the game states.
+            </p>
+        </section>
     </main>
-  </body>
+</body>
 </html>
+```

--- a/KharynaSerhii/index.html
+++ b/KharynaSerhii/index.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Статичний інтерфейс гри Сапер для лабораторної роботи з HTML та CSS."
+    />
+    <title>Сапер — Kharyna Serhii</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@600;700&family=Nunito:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="game" aria-labelledby="game-title">
+      <header class="game__header">
+        <p class="game__eyebrow">Класична головоломка</p>
+        <h1 id="game-title">Сапер</h1>
+
+        <div class="game__controls" aria-label="Панель керування грою">
+          <div class="indicator" aria-label="Залишилося прапорців: 6">
+            <span class="indicator__icon" aria-hidden="true">⚑</span>
+            <span class="indicator__value">006</span>
+            <span class="indicator__label">прапорців</span>
+          </div>
+
+          <button class="restart-button" type="button" aria-label="Почати нову гру">
+            <span aria-hidden="true">🙂</span>
+            <span class="restart-button__text">Нова гра</span>
+          </button>
+
+          <div class="indicator" aria-label="Час гри: 42 секунди">
+            <span class="indicator__icon" aria-hidden="true">◷</span>
+            <span class="indicator__value">042</span>
+            <span class="indicator__label">секунд</span>
+          </div>
+        </div>
+      </header>
+
+      <section class="board-section" aria-label="Ігрове поле Сапера">
+        <p class="board-section__hint">Ліва кнопка — відкрити · Права — поставити прапорець</p>
+        <div class="board" role="grid" aria-label="Ігрове поле 9 на 9 клітинок">
+          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 1, стовпець 1, відкрита, одна міна поруч">1</button>
+          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 1, стовпець 2, відкрита, порожня"></button>
+          <button class="cell cell--opened cell--number-2" type="button" role="gridcell" aria-label="Рядок 1, стовпець 3, відкрита, дві міни поруч">2</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 4, закрита"></button>
+          <button class="cell cell--closed cell--flag cell--flag-on-mine" type="button" role="gridcell" aria-label="Рядок 1, стовпець 5, міна позначена прапорцем">⚑</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 1, стовпець 9, закрита"></button>
+
+          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 2, стовпець 1, відкрита, порожня"></button>
+          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 2, стовпець 2, відкрита, одна міна поруч">1</button>
+          <button class="cell cell--opened cell--number-3" type="button" role="gridcell" aria-label="Рядок 2, стовпець 3, відкрита, три міни поруч">3</button>
+          <button class="cell cell--closed cell--flag cell--flag-without-mine" type="button" role="gridcell" aria-label="Рядок 2, стовпець 4, порожня клітинка неправильно позначена прапорцем">⚑</button>
+          <button class="cell cell--mine" type="button" role="gridcell" aria-label="Рядок 2, стовпець 5, міна">✹</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 2, стовпець 9, закрита"></button>
+
+          <button class="cell cell--opened" type="button" role="gridcell" aria-label="Рядок 3, стовпець 1, відкрита, порожня"></button>
+          <button class="cell cell--opened cell--number-1" type="button" role="gridcell" aria-label="Рядок 3, стовпець 2, відкрита, одна міна поруч">1</button>
+          <button class="cell cell--opened cell--number-2" type="button" role="gridcell" aria-label="Рядок 3, стовпець 3, відкрита, дві міни поруч">2</button>
+          <button class="cell cell--opened cell--number-4" type="button" role="gridcell" aria-label="Рядок 3, стовпець 4, відкрита, чотири міни поруч">4</button>
+          <button class="cell cell--mine cell--mine-hit" type="button" role="gridcell" aria-label="Рядок 3, стовпець 5, підірвана міна">✹</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 7, закрита"></button>
+          <button class="cell cell--closed cell--flag" type="button" role="gridcell" aria-label="Рядок 3, стовпець 8, позначена прапорцем">⚑</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 3, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 3, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 4, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 4, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 3, закрита"></button>
+          <button class="cell cell--closed cell--flag" type="button" role="gridcell" aria-label="Рядок 5, стовпець 4, позначена прапорцем">⚑</button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 5, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 3, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 4, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 6, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 3, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 4, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 7, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 3, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 4, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 8, стовпець 9, закрита"></button>
+
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 1, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 2, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 3, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 4, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 5, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 6, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 7, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 8, закрита"></button>
+          <button class="cell cell--closed" type="button" role="gridcell" aria-label="Рядок 9, стовпець 9, закрита"></button>
+        </div>
+        <p class="game-message" role="status" aria-live="polite">Гра триває. Знайдіть усі міни!</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/KharynaSerhii/styles.css
+++ b/KharynaSerhii/styles.css
@@ -2,7 +2,7 @@
   --board-columns: 9;
   --cell-size: clamp(2rem, 8.5vw, 3.25rem);
   --page-background: #f5f7ff;
-  --surface: #ffffff;
+  --surface: #fff;
   --ink: #19253e;
   --muted-ink: #65718a;
   --accent: #5069e8;
@@ -42,16 +42,16 @@ button {
   padding: 3rem 0;
 }
 
-.game__header {
+.game-header {
   padding: clamp(1.5rem, 5vw, 2.5rem);
   border-radius: var(--border-radius) var(--border-radius) 0 0;
-  color: #ffffff;
+  color: #fff;
   text-align: center;
   background: linear-gradient(135deg, #334ac0, #657cff);
   box-shadow: 0 1.25rem 3.75rem rgb(54 77 157 / 18%);
 }
 
-.game__eyebrow {
+.game-eyebrow {
   margin: 0;
   color: #dce3ff;
   font-size: 0.75rem;
@@ -66,7 +66,7 @@ h1 {
   line-height: 1;
 }
 
-.game__controls {
+.game-controls {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   gap: 1rem;
@@ -81,7 +81,7 @@ h1 {
   text-align: left;
 }
 
-.indicator__icon {
+.indicator-icon {
   grid-row: span 2;
   color: #f5c34c;
   font-size: 1.65rem;
@@ -91,18 +91,18 @@ h1 {
   text-align: right;
 }
 
-.indicator:last-child .indicator__icon {
+.indicator:last-child .indicator-icon {
   color: #bdf0e4;
 }
 
-.indicator__value {
+.indicator-value {
   font-family: "JetBrains Mono", monospace;
   font-size: 1.1rem;
   font-weight: 700;
   line-height: 1;
 }
 
-.indicator__label {
+.indicator-label {
   color: #dce3ff;
   font-size: 0.7rem;
   font-weight: 700;
@@ -119,7 +119,7 @@ h1 {
   color: var(--ink);
   font-size: 1.6rem;
   cursor: pointer;
-  background: #ffffff;
+  background: #fff;
   box-shadow: 0 0.25rem 0 #d8def9;
   transition: transform 150ms ease, box-shadow 150ms ease;
 }
@@ -134,7 +134,7 @@ h1 {
   box-shadow: 0 0.1rem 0 #d8def9;
 }
 
-.restart-button__text {
+.restart-button-text {
   font-size: 0.65rem;
   font-weight: 800;
   text-transform: uppercase;
@@ -147,7 +147,7 @@ h1 {
   box-shadow: 0 1.25rem 3.75rem rgb(54 77 157 / 18%);
 }
 
-.board-section__hint,
+.board-section-hint,
 .game-message {
   margin: 0;
   color: var(--muted-ink);
@@ -156,7 +156,7 @@ h1 {
   text-align: center;
 }
 
-.board-section__hint {
+.board-section-hint {
   margin-bottom: 1.25rem;
 }
 
@@ -183,65 +183,65 @@ h1 {
   font-weight: 700;
 }
 
-.cell--closed {
-  color: #ffffff;
+.cell-closed {
+  color: #fff;
   cursor: pointer;
   background: var(--closed-cell);
   box-shadow: inset 0 -0.2rem 0 var(--closed-cell-shadow);
   transition: background 150ms ease, transform 150ms ease;
 }
 
-.cell--closed:hover {
+.cell-closed:hover {
   background: #8ca0ff;
   transform: translateY(-0.1rem);
 }
 
-.cell--opened {
+.cell-opened {
   color: var(--ink);
   background: var(--opened-cell);
 }
 
-.cell--number-1 {
+.cell-number-1 {
   color: #2e78d6;
 }
 
-.cell--number-2 {
+.cell-number-2 {
   color: #2d9d65;
 }
 
-.cell--number-3 {
+.cell-number-3 {
   color: #dc5e56;
 }
 
-.cell--number-4 {
+.cell-number-4 {
   color: #7658c6;
 }
 
-.cell--flag {
+.cell-flag {
   color: #fff4ca;
   font-size: 1.6rem;
 }
 
-.cell--flag-on-mine {
+.cell-flag-on-mine {
   text-shadow: 0 0.1rem 0 var(--closed-cell-shadow);
 }
 
-.cell--mine {
-  color: #ffffff;
+.cell-mine {
+  color: #fff;
   background: var(--mine);
 }
 
-.cell--mine-hit {
-  color: #ffffff;
+.cell-mine-hit {
+  color: #fff;
   background: var(--danger);
   box-shadow: inset 0 0 0 0.15rem #ff9ca7;
 }
 
-.cell--flag-without-mine {
+.cell-flag-without-mine {
   position: relative;
 }
 
-.cell--flag-without-mine::after {
+.cell-flag-without-mine::after {
   position: absolute;
   width: 125%;
   height: 0.16rem;
@@ -261,22 +261,22 @@ h1 {
   margin-top: 1.25rem;
 }
 
-@media (max-width: 28rem) {
+@media (width <= 28rem) {
   .game {
     width: min(100% - 1rem, 42rem);
     padding: 1rem 0;
   }
 
-  .game__header,
+  .game-header,
   .board-section {
     padding: 1.25rem 0.75rem;
   }
 
-  .game__controls {
+  .game-controls {
     gap: 0.5rem;
   }
 
-  .indicator__label {
+  .indicator-label {
     font-size: 0.6rem;
   }
 
@@ -286,7 +286,7 @@ h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cell--closed,
+  .cell-closed,
   .restart-button {
     transition: none;
   }

--- a/KharynaSerhii/styles.css
+++ b/KharynaSerhii/styles.css
@@ -1,0 +1,293 @@
+:root {
+  --board-columns: 9;
+  --cell-size: clamp(2rem, 8.5vw, 3.25rem);
+  --page-background: #f5f7ff;
+  --surface: #ffffff;
+  --ink: #19253e;
+  --muted-ink: #65718a;
+  --accent: #5069e8;
+  --accent-dark: #344cc5;
+  --closed-cell: #7890ff;
+  --closed-cell-shadow: #526bdc;
+  --opened-cell: #edf0f8;
+  --mine: #27334e;
+  --danger: #f45467;
+  --cell-font-size: 1.25rem;
+  --border-radius: 1.25rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 20rem;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--ink);
+  font-family: Nunito, Arial, sans-serif;
+  background:
+    radial-gradient(circle at 15% 15%, #dce3ff 0, transparent 29rem),
+    radial-gradient(circle at 85% 85%, #d8f3ed 0, transparent 25rem),
+    var(--page-background);
+}
+
+button {
+  font: inherit;
+}
+
+.game {
+  width: min(100% - 2rem, 42rem);
+  margin: 0 auto;
+  padding: 3rem 0;
+}
+
+.game__header {
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+  color: #ffffff;
+  text-align: center;
+  background: linear-gradient(135deg, #334ac0, #657cff);
+  box-shadow: 0 1.25rem 3.75rem rgb(54 77 157 / 18%);
+}
+
+.game__eyebrow {
+  margin: 0;
+  color: #dce3ff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0.25rem 0 1.5rem;
+  font-size: clamp(2.25rem, 8vw, 3.5rem);
+  line-height: 1;
+}
+
+.game__controls {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.indicator {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.4rem;
+  align-items: center;
+  text-align: left;
+}
+
+.indicator__icon {
+  grid-row: span 2;
+  color: #f5c34c;
+  font-size: 1.65rem;
+}
+
+.indicator:last-child {
+  text-align: right;
+}
+
+.indicator:last-child .indicator__icon {
+  color: #bdf0e4;
+}
+
+.indicator__value {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.indicator__label {
+  color: #dce3ff;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.restart-button {
+  display: grid;
+  gap: 0.1rem;
+  place-items: center;
+  min-width: 5.5rem;
+  min-height: 4.25rem;
+  border: 0;
+  border-radius: 0.9rem;
+  color: var(--ink);
+  font-size: 1.6rem;
+  cursor: pointer;
+  background: #ffffff;
+  box-shadow: 0 0.25rem 0 #d8def9;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.restart-button:hover {
+  transform: translateY(-0.15rem);
+  box-shadow: 0 0.4rem 0 #d8def9;
+}
+
+.restart-button:active {
+  transform: translateY(0.15rem);
+  box-shadow: 0 0.1rem 0 #d8def9;
+}
+
+.restart-button__text {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.board-section {
+  padding: clamp(1.25rem, 5vw, 2.5rem);
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  background: var(--surface);
+  box-shadow: 0 1.25rem 3.75rem rgb(54 77 157 / 18%);
+}
+
+.board-section__hint,
+.game-message {
+  margin: 0;
+  color: var(--muted-ink);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.board-section__hint {
+  margin-bottom: 1.25rem;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(var(--board-columns), var(--cell-size));
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.35rem;
+  border-radius: 0.85rem;
+  background: #cfd6e8;
+}
+
+.cell {
+  display: grid;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  padding: 0;
+  border: 0;
+  border-radius: 0.35rem;
+  place-items: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: var(--cell-font-size);
+  font-weight: 700;
+}
+
+.cell--closed {
+  color: #ffffff;
+  cursor: pointer;
+  background: var(--closed-cell);
+  box-shadow: inset 0 -0.2rem 0 var(--closed-cell-shadow);
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.cell--closed:hover {
+  background: #8ca0ff;
+  transform: translateY(-0.1rem);
+}
+
+.cell--opened {
+  color: var(--ink);
+  background: var(--opened-cell);
+}
+
+.cell--number-1 {
+  color: #2e78d6;
+}
+
+.cell--number-2 {
+  color: #2d9d65;
+}
+
+.cell--number-3 {
+  color: #dc5e56;
+}
+
+.cell--number-4 {
+  color: #7658c6;
+}
+
+.cell--flag {
+  color: #fff4ca;
+  font-size: 1.6rem;
+}
+
+.cell--flag-on-mine {
+  text-shadow: 0 0.1rem 0 var(--closed-cell-shadow);
+}
+
+.cell--mine {
+  color: #ffffff;
+  background: var(--mine);
+}
+
+.cell--mine-hit {
+  color: #ffffff;
+  background: var(--danger);
+  box-shadow: inset 0 0 0 0.15rem #ff9ca7;
+}
+
+.cell--flag-without-mine {
+  position: relative;
+}
+
+.cell--flag-without-mine::after {
+  position: absolute;
+  width: 125%;
+  height: 0.16rem;
+  border-radius: 999px;
+  content: "";
+  background: var(--danger);
+  transform: rotate(-45deg);
+}
+
+.cell:focus-visible,
+.restart-button:focus-visible {
+  outline: 0.2rem solid #f5c34c;
+  outline-offset: 0.2rem;
+}
+
+.game-message {
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 28rem) {
+  .game {
+    width: min(100% - 1rem, 42rem);
+    padding: 1rem 0;
+  }
+
+  .game__header,
+  .board-section {
+    padding: 1.25rem 0.75rem;
+  }
+
+  .game__controls {
+    gap: 0.5rem;
+  }
+
+  .indicator__label {
+    font-size: 0.6rem;
+  }
+
+  .restart-button {
+    min-width: 4.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cell--closed,
+  .restart-button {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What was done

- Created a static Minesweeper interface using HTML and CSS.
- Added a game header with a flag counter, timer, and new-game button.
- Added a responsive 9x9 board with closed, opened, flagged, mined, and exploded-cell states.

## Checklist

- [x] Changes are limited to the personal `KharynaSerhii` directory.
- [x] Lab 1 contains HTML and CSS only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an English-language static Minesweeper preview.
  * Added a 9×9 button-based board with updated cells, symbols, indicators, controls, and game messaging.
  * Added responsive layouts for desktop and mobile screens.
  * Added visual states for cells, controls, and keyboard focus.
  * Added reduced-motion support for users who prefer less animation.

* **Changes**
  * Replaced the Ukrainian-language game presentation and revised accessibility labels and board semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->