### PR TITLE
lab1:added basic minesweeper layout

### DIFF
--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -47,10 +47,10 @@
 
       <!-- Row 2: open cells (empty and with numbers 1-4) -->
       <button class="cell open" type="button" aria-label="Відкрита порожня" disabled></button>
-      <button class="cell open n1" type="button" disabled>1</button>
-      <button class="cell open n2" type="button" disabled>2</button>
-      <button class="cell open n3" type="button" disabled>3</button>
-      <button class="cell open n4" type="button" disabled>4</button>
+      <button class="cell open n1" type="button" aria-label="Відкрита клітинка, поруч одна міна" disabled>1</button>
+      <button class="cell open n2" type="button" aria-label="Відкрита клітинка, поруч дві міни" disabled>2</button>
+      <button class="cell open n3" type="button" aria-label="Відкрита клітинка, поруч три міни" disabled>3</button>
+      <button class="cell open n4" type="button" aria-label="Відкрита клітинка, поруч чотири міни" disabled>4</button>
 
       <!-- Row 3: flags -->
       <!-- Flag on a mine (correct) -->

--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Minesweeper-Hrabovyi</title>
+  <title>Minesweeper-Hrabovyi Ivan</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -16,7 +16,7 @@
     <header class="game-header">
 
       <!-- Flag counter -->
-      <div class="counter" id="flag-counter" aria-label="Залишилось прапорців: 5">
+      <div class="counter" id="flag-counter" role="status" aria-label="Залишилось прапорців: 5">
         <span class="counter-icon" aria-hidden="true">🚩</span>
         <span class="counter-value">05</span>
       </div>

--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -12,7 +12,7 @@
   <header class="game-header">
 
     <!-- Flag counter -->
-    <div class="counter" id="flag-counter" role="status" aria-label="Залишилось прапорців: 5">
+    <div class="counter" id="flag-counter" role="status" aria-live="polite" aria-label="Залишилось прапорців: 5">
       <span class="counter-icon" aria-hidden="true">🚩</span>
       <span class="counter-value">05</span>
     </div>

--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -8,31 +8,31 @@
 </head>
 <body>
 
+  <!-- ==================== Game header ==================== -->
+  <header class="game-header">
+
+    <!-- Flag counter -->
+    <div class="counter" id="flag-counter" role="status" aria-label="Залишилось прапорців: 5">
+      <span class="counter-icon" aria-hidden="true">🚩</span>
+      <span class="counter-value">05</span>
+    </div>
+
+    <!-- Start button (new game) -->
+    <button class="start-btn" id="start-btn" type="button" aria-label="Нова гра">
+      <span aria-hidden="true">⏯</span>
+    </button>
+
+    <!-- Timer -->
+    <div class="counter" id="timer" aria-label="Час гри: 0 секунд">
+      <span class="counter-icon" aria-hidden="true">⏱</span>
+      <span class="counter-value">000</span>
+    </div>
+
+  </header>
+
   <main class="game">
 
     <h1 class="visually-hidden">Сапер 5x5</h1>
-
-    <!-- ==================== Game header ==================== -->
-    <header class="game-header">
-
-      <!-- Flag counter -->
-      <div class="counter" id="flag-counter" role="status" aria-label="Залишилось прапорців: 5">
-        <span class="counter-icon" aria-hidden="true">🚩</span>
-        <span class="counter-value">05</span>
-      </div>
-
-      <!-- Start button (new game) -->
-      <button class="start-btn" id="start-btn" type="button" aria-label="Нова гра">
-        <span aria-hidden="true">⏯</span>
-      </button>
-
-      <!-- Timer -->
-      <div class="counter" id="timer" aria-label="Час гри: 0 секунд">
-        <span class="counter-icon" aria-hidden="true">⏱</span>
-        <span class="counter-value">000</span>
-      </div>
-
-    </header>
 
     <!-- ==================== 5x5 game board ==================== -->
     <!-- The cells below demonstrate all possible states -->

--- a/HrabovyiIvan/index.html
+++ b/HrabovyiIvan/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Minesweeper-Hrabovyi</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+  <main class="game">
+
+    <h1 class="visually-hidden">Сапер 5x5</h1>
+
+    <!-- ==================== Game header ==================== -->
+    <header class="game-header">
+
+      <!-- Flag counter -->
+      <div class="counter" id="flag-counter" aria-label="Залишилось прапорців: 5">
+        <span class="counter-icon" aria-hidden="true">🚩</span>
+        <span class="counter-value">05</span>
+      </div>
+
+      <!-- Start button (new game) -->
+      <button class="start-btn" id="start-btn" type="button" aria-label="Нова гра">
+        <span aria-hidden="true">⏯</span>
+      </button>
+
+      <!-- Timer -->
+      <div class="counter" id="timer" aria-label="Час гри: 0 секунд">
+        <span class="counter-icon" aria-hidden="true">⏱</span>
+        <span class="counter-value">000</span>
+      </div>
+
+    </header>
+
+    <!-- ==================== 5x5 game board ==================== -->
+    <!-- The cells below demonstrate all possible states -->
+    <div class="board" id="board" aria-label="Ігрове поле 5 на 5">
+
+      <!-- Row 1: closed cells -->
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+
+      <!-- Row 2: open cells (empty and with numbers 1-4) -->
+      <button class="cell open" type="button" aria-label="Відкрита порожня" disabled></button>
+      <button class="cell open n1" type="button" disabled>1</button>
+      <button class="cell open n2" type="button" disabled>2</button>
+      <button class="cell open n3" type="button" disabled>3</button>
+      <button class="cell open n4" type="button" disabled>4</button>
+
+      <!-- Row 3: flags -->
+      <!-- Flag on a mine (correct) -->
+      <button class="cell flagged" type="button" aria-label="Прапорець на міні"></button>
+      <!-- Flag without a mine (after game over — wrong, crossed-out mine) -->
+      <button class="cell flagged wrong" type="button" aria-label="Помилковий прапорець" disabled></button>
+      <button class="cell flagged" type="button" aria-label="Прапорець"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+
+      <!-- Row 4: mines -->
+      <!-- Regular revealed mine (shown on loss) -->
+      <button class="cell open mine" type="button" aria-label="Міна" disabled></button>
+      <!-- Mine the user clicked on (exploded) -->
+      <button class="cell open mine exploded" type="button" aria-label="Міна, що вибухнула" disabled></button>
+      <button class="cell open mine" type="button" aria-label="Міна" disabled></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+      <button class="cell" type="button" aria-label="Закрита клітинка"></button>
+
+      <!-- Row 5: open cells with numbers 5-8 and an empty cell -->
+      <button class="cell open n5" type="button" disabled>5</button>
+      <button class="cell open n6" type="button" disabled>6</button>
+      <button class="cell open n7" type="button" disabled>7</button>
+      <button class="cell open n8" type="button" disabled>8</button>
+      <button class="cell open" type="button" aria-label="Відкрита порожня" disabled></button>
+
+    </div>
+
+  </main>
+
+</body>
+</html>

--- a/HrabovyiIvan/styles.css
+++ b/HrabovyiIvan/styles.css
@@ -12,7 +12,7 @@
   --danger: #e5484d;
   --text-light: #eef2f7;
 
-  /* Board size css */
+  /* Board size */
   --board-size: 5;
   --gap: 4px;
 }
@@ -52,7 +52,7 @@ body {
   background: var(--panel);
   border-radius: 16px;
   padding: clamp(12px, 3vw, 20px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 45%);
 }
 
 /* ==================== Header ==================== */
@@ -139,13 +139,12 @@ body {
   user-select: none;
 }
 
-/* --- Closed cell --- */
-/* A raised, "convex" tile */
+/* Closed cell — a raised, "convex" tile */
 .cell:not(.open) {
   background: linear-gradient(145deg, var(--cell-closed-light), var(--cell-closed));
   box-shadow:
-    inset 2px 2px 3px rgba(255, 255, 255, 0.45),
-    inset -2px -2px 3px rgba(0, 0, 0, 0.3);
+    inset 2px 2px 3px rgb(255 255 255 / 45%),
+    inset -2px -2px 3px rgb(0 0 0 / 30%);
   transition: filter 0.1s ease;
 }
 
@@ -154,11 +153,10 @@ body {
 }
 
 .cell:not(.open):active {
-  box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 2px 2px 4px rgb(0 0 0 / 30%);
 }
 
-/* --- Open cell --- */
-/* Flat, "pressed in" */
+/* Open cell — flat, "pressed in" */
 .cell.open {
   background: var(--cell-open);
   box-shadow: inset 0 0 0 1px var(--cell-open-border);
@@ -172,7 +170,7 @@ body {
 .cell.n4 { color: #14349c; }
 .cell.n5 { color: #8a2f22; }
 .cell.n6 { color: #1f8f8f; }
-.cell.n7 { color: #222222; }
+.cell.n7 { color: #222; }
 .cell.n8 { color: #6b6b6b; }
 
 /* ==================== Flagged cell ==================== */
@@ -232,7 +230,7 @@ body {
 
 /* ==================== Responsiveness ==================== */
 
-@media (max-width: 360px) {
+@media (width <= 360px) {
   .game-header {
     flex-wrap: wrap;
     justify-content: center;
@@ -244,7 +242,7 @@ body {
   }
 }
 
-@media (min-width: 720px) {
+@media (width >= 720px) {
   .game {
     width: 440px;
   }

--- a/HrabovyiIvan/styles.css
+++ b/HrabovyiIvan/styles.css
@@ -1,0 +1,251 @@
+:root {
+  /* Color palette */
+  --bg: #1e2530;
+  --panel: #2b3442;
+  --panel-dark: #232b37;
+  --cell-closed: #8fa3bf;
+  --cell-closed-light: #b4c5dd;
+  --cell-closed-dark: #64778f;
+  --cell-open: #dde5ee;
+  --cell-open-border: #c3cedb;
+  --accent: #ffd166;
+  --danger: #e5484d;
+  --text-light: #eef2f7;
+
+  /* Board size */
+  --board-size: 5;
+  --gap: 4px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+/* Screen-reader-only heading, visually hidden */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: radial-gradient(circle at 50% 20%, #2a3547, var(--bg));
+  font-family: "Segoe UI", system-ui, sans-serif;
+  color: var(--text-light);
+}
+
+/* ==================== Game container ==================== */
+
+.game {
+  width: min(92vw, 420px);
+  background: var(--panel);
+  border-radius: 16px;
+  padding: clamp(12px, 3vw, 20px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+/* ==================== Header ==================== */
+
+.game-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--panel-dark);
+  border-radius: 12px;
+  padding: 10px 14px;
+  margin-bottom: clamp(12px, 3vw, 18px);
+}
+
+.counter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 72px;
+  background: #141a22;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.counter-icon {
+  font-size: 1rem;
+}
+
+.counter-value {
+  font-size: clamp(1rem, 4vw, 1.25rem);
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 1px;
+}
+
+.start-btn {
+  font-size: clamp(1.4rem, 6vw, 1.8rem);
+  line-height: 1;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  background: linear-gradient(180deg, var(--cell-closed-light), var(--cell-closed));
+  box-shadow: 0 3px 0 var(--cell-closed-dark);
+  transition: transform 0.08s ease, box-shadow 0.08s ease;
+}
+
+.start-btn:hover {
+  filter: brightness(1.05);
+}
+
+.start-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 var(--cell-closed-dark);
+}
+
+/* ==================== Game board ==================== */
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(var(--board-size), 1fr);
+  gap: var(--gap);
+  background: var(--panel-dark);
+  border-radius: 12px;
+  padding: var(--gap);
+}
+
+/* ==================== Cell: base state ==================== */
+
+.cell {
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  padding: 0;
+  font-family: inherit;
+  font-size: clamp(1rem, 5vw, 1.5rem);
+  font-weight: 800;
+  cursor: pointer;
+  user-select: none;
+}
+
+/* --- Closed cell --- */
+/* A raised, "convex" tile */
+.cell:not(.open) {
+  background: linear-gradient(145deg, var(--cell-closed-light), var(--cell-closed));
+  box-shadow:
+    inset 2px 2px 3px rgba(255, 255, 255, 0.45),
+    inset -2px -2px 3px rgba(0, 0, 0, 0.3);
+  transition: filter 0.1s ease;
+}
+
+.cell:not(.open):hover {
+  filter: brightness(1.08);
+}
+
+.cell:not(.open):active {
+  box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* --- Open cell --- */
+/* Flat, "pressed in" */
+.cell.open {
+  background: var(--cell-open);
+  box-shadow: inset 0 0 0 1px var(--cell-open-border);
+  cursor: default;
+}
+
+/* Number colors */
+.cell.n1 { color: #1d6fd6; }
+.cell.n2 { color: #1e8a3c; }
+.cell.n3 { color: #d63a3a; }
+.cell.n4 { color: #14349c; }
+.cell.n5 { color: #8a2f22; }
+.cell.n6 { color: #1f8f8f; }
+.cell.n7 { color: #222222; }
+.cell.n8 { color: #6b6b6b; }
+
+/* ==================== Flagged cell ==================== */
+
+/* Flag (closed cell with a mark) — looks the same while the game
+   is in progress; revealed as correct only if it was on a mine */
+.cell.flagged::before {
+  content: "🚩";
+  font-size: 0.85em;
+}
+
+/* Wrong flag (no mine underneath) — shown after game over:
+   a crossed-out mine */
+.cell.flagged.wrong {
+  position: relative;
+  background: linear-gradient(145deg, #e8c2c2, #d49a9a);
+}
+
+.cell.flagged.wrong::before {
+  content: "💣";
+}
+
+.cell.flagged.wrong::after {
+  content: "";
+  position: absolute;
+  width: 70%;
+  height: 3px;
+  background: var(--danger);
+  transform: rotate(-45deg);
+  border-radius: 2px;
+}
+
+/* ==================== Mine cell ==================== */
+
+/* Regular revealed mine (all mines shown on loss) */
+.cell.mine::before {
+  content: "💣";
+  font-size: 0.85em;
+}
+
+/* Mine the user clicked on — exploded */
+.cell.mine.exploded {
+  background: radial-gradient(circle, #ff8a80 0%, var(--danger) 70%);
+  box-shadow: inset 0 0 0 2px #b93035;
+  animation: explode 0.35s ease-out;
+}
+
+.cell.mine.exploded::before {
+  content: "💥";
+}
+
+@keyframes explode {
+  0%   { transform: scale(0.6); }
+  60%  { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+/* ==================== Responsiveness ==================== */
+
+@media (max-width: 360px) {
+  .game-header {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .counter {
+    min-width: 60px;
+    padding: 4px 8px;
+  }
+}
+
+@media (min-width: 720px) {
+  .game {
+    width: 440px;
+  }
+}

--- a/HrabovyiIvan/styles.css
+++ b/HrabovyiIvan/styles.css
@@ -62,10 +62,11 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: min(92vw, 420px);
+  margin: 0 auto clamp(12px, 3vw, 18px);
   background: var(--panel-dark);
   border-radius: 12px;
   padding: 10px 14px;
-  margin-bottom: clamp(12px, 3vw, 18px);
 }
 
 .counter {
@@ -243,7 +244,8 @@ body {
 }
 
 @media (width >= 720px) {
-  .game {
+  .game,
+  .game-header {
     width: 440px;
   }
 }

--- a/HrabovyiIvan/styles.css
+++ b/HrabovyiIvan/styles.css
@@ -12,7 +12,7 @@
   --danger: #e5484d;
   --text-light: #eef2f7;
 
-  /* Board size */
+  /* Board size css */
   --board-size: 5;
   --gap: 4px;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -118,7 +117,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -167,7 +165,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -518,7 +515,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -780,7 +776,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -887,7 +882,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1836,7 +1830,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -1886,7 +1879,6 @@
       "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"


### PR DESCRIPTION
## What was done

- Created a dedicated  folder containing index.html and styles.css.
- Implemented the static game header with controls: restart button, mine/flag counter, and elapsed timer display.
- added 5x5 board with all required cell states

## Screenshots
<img width="1897" height="997" alt="image" src="https://github.com/user-attachments/assets/cd948251-8445-4c84-aecb-209636dde144" />



## Checklist

- [ ] PR title follows the format `lab{number}: Short description` (e.g. `lab1: Add layout`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dark-themed, responsive Minesweeper interface.
  - Added a header with a mine counter, new-game button, and timer.
  - Added styling for the 5×5 board and cell states, including flagged, incorrectly flagged, mined, and exploded cells.
  - Added number-specific cell colors and an explosion animation.
  - Added responsive layouts for narrow and wide screens.
  - Organized game controls in a separate header while keeping the board within the main content area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->