### PR TITLE
Lab1: basic ui layout

### DIFF
--- a/FedorchenkoDaria/index.html
+++ b/FedorchenkoDaria/index.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Minesweeper</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+
+  <body>
+    <main class="game">
+      <header class="game-header">
+        <div class="counter" aria-label="кількість прапорців">
+          <svg
+            class="counter__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528"
+            />
+          </svg>
+          <span class="counter__value">010</span>
+        </div>
+
+        <button class="restart-btn" type="button" aria-label="почати нову гру">
+          <svg
+            class="restart-btn__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"
+            />
+          </svg>
+        </button>
+
+        <div class="counter" aria-label="час гри">
+          <svg
+            class="counter__icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="10" x2="14" y1="2" y2="2" />
+            <line x1="12" x2="15" y1="14" y2="11" />
+            <circle cx="12" cy="14" r="8" />
+          </svg>
+          <span class="counter__value">000</span>
+        </div>
+      </header>
+
+      <section class="board" aria-label="ігрове поле">
+        <div class="board__row">
+          <button class="cell" data-state="open" type="button"></button>
+          <button class="cell" data-state="open" data-count="1" type="button">
+            1
+          </button>
+          <button class="cell" data-state="open" data-count="2" type="button">
+            2
+          </button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="open" data-count="3" type="button">
+            3
+          </button>
+          <button class="cell" data-state="open" data-count="4" type="button">
+            4
+          </button>
+          <button class="cell" data-state="closed" type="button"></button>
+        </div>
+
+        <div class="board__row">
+          <button class="cell" data-state="open" data-count="1" type="button">
+            1
+          </button>
+          <button class="cell" data-state="flag" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="open" data-count="1" type="button">
+            1
+          </button>
+          <button class="cell" data-state="open" type="button"></button>
+        </div>
+
+        <div class="board__row">
+          <button class="cell" data-state="open" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button
+            class="cell"
+            data-state="mine-exploded"
+            type="button"
+          ></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="open" type="button"></button>
+        </div>
+
+        <div class="board__row">
+          <button class="cell" data-state="open" data-count="2" type="button">
+            2
+          </button>
+          <button class="cell" data-state="flag" type="button"></button>
+          <button class="cell" data-state="mine" type="button"></button>
+          <button class="cell" data-state="mine" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="open" data-count="1" type="button">
+            1
+          </button>
+        </div>
+
+        <div class="board__row">
+          <button class="cell" data-state="open" type="button"></button>
+          <button class="cell" data-state="open" data-count="1" type="button">
+            1
+          </button>
+          <button class="cell" data-state="flag" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+        </div>
+
+        <div class="board__row">
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="open" data-count="3" type="button">
+            3
+          </button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+          <button class="cell" data-state="closed" type="button"></button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/FedorchenkoDaria/index.html
+++ b/FedorchenkoDaria/index.html
@@ -77,94 +77,340 @@
       </header>
 
       <section class="board" aria-label="ігрове поле">
-        <div class="board__row">
-          <button class="cell" data-state="open" type="button"></button>
-          <button class="cell" data-state="open" data-count="1" type="button">
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="open"
+            type="button"
+            aria-label="Рядок 1, стовпчик 1, порожня відкрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="1"
+            type="button"
+            aria-label="Рядок 1, стовпчик 2, відкрита, 1 міна поряд"
+          >
             1
           </button>
-          <button class="cell" data-state="open" data-count="2" type="button">
+          <button
+            class="cell"
+            data-state="open"
+            data-count="2"
+            type="button"
+            aria-label="Рядок 1, стовпчик 3, відкрита, 2 міни поряд"
+          >
             2
           </button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="open" data-count="3" type="button">
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 1, стовпчик 4, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 1, стовпчик 5, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="3"
+            type="button"
+            aria-label="Рядок 1, стовпчик 6, відкрита, 3 міни поряд"
+          >
             3
           </button>
-          <button class="cell" data-state="open" data-count="4" type="button">
+          <button
+            class="cell"
+            data-state="open"
+            data-count="4"
+            type="button"
+            aria-label="Рядок 1, стовпчик 7, відкрита, 4 міни поряд"
+          >
             4
           </button>
-          <button class="cell" data-state="closed" type="button"></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 1, стовпчик 8, закрита клітинка"
+          ></button>
         </div>
 
-        <div class="board__row">
-          <button class="cell" data-state="open" data-count="1" type="button">
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="open"
+            data-count="1"
+            type="button"
+            aria-label="Рядок 2, стовпчик 1, відкрита, 1 міна поряд"
+          >
             1
           </button>
-          <button class="cell" data-state="flag" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="open" data-count="1" type="button">
+          <button
+            class="cell"
+            data-state="flag-safe"
+            type="button"
+            aria-label="Рядок 2, стовпчик 2, прапорець на безпечній клітинці"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 2, стовпчик 3, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 2, стовпчик 4, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 2, стовпчик 5, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 2, стовпчик 6, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="1"
+            type="button"
+            aria-label="Рядок 2, стовпчик 7, відкрита, 1 міна поряд"
+          >
             1
           </button>
-          <button class="cell" data-state="open" type="button"></button>
+          <button
+            class="cell"
+            data-state="open"
+            type="button"
+            aria-label="Рядок 2, стовпчик 8, порожня відкрита клітинка"
+          ></button>
         </div>
 
-        <div class="board__row">
-          <button class="cell" data-state="open" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="open"
+            type="button"
+            aria-label="Рядок 3, стовпчик 1, порожня відкрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 3, стовпчик 2, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 3, стовпчик 3, закрита клітинка"
+          ></button>
           <button
             class="cell"
             data-state="mine-exploded"
             type="button"
+            aria-label="Рядок 3, стовпчик 4, вибухнула міна"
           ></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="open" type="button"></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 3, стовпчик 5, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 3, стовпчик 6, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 3, стовпчик 7, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            type="button"
+            aria-label="Рядок 3, стовпчик 8, порожня відкрита клітинка"
+          ></button>
         </div>
 
-        <div class="board__row">
-          <button class="cell" data-state="open" data-count="2" type="button">
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="open"
+            data-count="2"
+            type="button"
+            aria-label="Рядок 4, стовпчик 1, відкрита, 2 міни поряд"
+          >
             2
           </button>
-          <button class="cell" data-state="flag" type="button"></button>
-          <button class="cell" data-state="mine" type="button"></button>
-          <button class="cell" data-state="mine" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="open" data-count="1" type="button">
+          <button
+            class="cell"
+            data-state="flag-mine"
+            type="button"
+            aria-label="Рядок 4, стовпчик 2, прапорець на міні"
+          ></button>
+          <button
+            class="cell"
+            data-state="mine"
+            type="button"
+            aria-label="Рядок 4, стовпчик 3, міна"
+          ></button>
+          <button
+            class="cell"
+            data-state="mine"
+            type="button"
+            aria-label="Рядок 4, стовпчик 4, міна"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 4, стовпчик 5, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 4, стовпчик 6, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 4, стовпчик 7, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="1"
+            type="button"
+            aria-label="Рядок 4, стовпчик 8, відкрита, 1 міна поряд"
+          >
             1
           </button>
         </div>
 
-        <div class="board__row">
-          <button class="cell" data-state="open" type="button"></button>
-          <button class="cell" data-state="open" data-count="1" type="button">
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="open"
+            type="button"
+            aria-label="Рядок 5, стовпчик 1, порожня відкрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="1"
+            type="button"
+            aria-label="Рядок 5, стовпчик 2, відкрита, 1 міна поряд"
+          >
             1
           </button>
-          <button class="cell" data-state="flag" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
+          <button
+            class="cell"
+            data-state="flag-mine"
+            type="button"
+            aria-label="Рядок 5, стовпчик 3, прапорець на міні"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 5, стовпчик 4, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 5, стовпчик 5, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 5, стовпчик 6, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 5, стовпчик 7, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 5, стовпчик 8, закрита клітинка"
+          ></button>
         </div>
 
-        <div class="board__row">
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="open" data-count="3" type="button">
+        <div class="board-row">
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 1, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 2, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 3, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 4, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="open"
+            data-count="3"
+            type="button"
+            aria-label="Рядок 6, стовпчик 5, відкрита, 3 міни поряд"
+          >
             3
           </button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
-          <button class="cell" data-state="closed" type="button"></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 6, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 7, закрита клітинка"
+          ></button>
+          <button
+            class="cell"
+            data-state="closed"
+            type="button"
+            aria-label="Рядок 6, стовпчик 8, закрита клітинка"
+          ></button>
         </div>
       </section>
     </main>

--- a/FedorchenkoDaria/styles.css
+++ b/FedorchenkoDaria/styles.css
@@ -1,0 +1,236 @@
+:root {
+  --pink: #c51f5d;
+  --blue: #243447;
+  --navy: #141d26;
+  --cream: #e2e2d2;
+
+  --pink-soft: color-mix(in srgb, var(--pink) 55%, var(--navy));
+  --blue-soft: color-mix(in srgb, var(--blue) 70%, var(--cream));
+  --cream-dim: color-mix(in srgb, var(--cream) 70%, var(--navy));
+
+  --radius-s: 6px;
+  --radius-m: 12px;
+  --radius-l: 20px;
+
+  --gap: clamp(4px, 1.2vw, 8px);
+  --cell-size: clamp(34px, 9vw, 52px);
+
+  font-size: 16px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: var(--navy);
+  font-family: "Outfit", system-ui, sans-serif;
+  color: var(--cream);
+}
+.game {
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.game-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  background: var(--blue);
+  border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
+  border-radius: var(--radius-l);
+  box-shadow: 0 12px 30px -14px rgba(0, 0, 0, 0.6);
+}
+
+.counter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 84px;
+  padding: 8px 12px;
+  background: var(--navy);
+  border-radius: var(--radius-m);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.counter__value {
+  font-size: 1.1rem;
+}
+
+.counter__icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  stroke: var(--pink);
+}
+
+.counter:last-child .counter__icon {
+  stroke: var(--cream);
+}
+
+.restart-btn {
+  width: 46px;
+  height: 46px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--pink);
+  color: var(--cream);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.restart-btn:hover {
+  background: var(--pink-soft);
+}
+
+.restart-btn__icon {
+  width: 22px;
+  height: 22px;
+  stroke: var(--cream);
+  fill: var(--cream);
+  margin-left: 2px;
+  transition: transform 0.2s ease;
+}
+
+.board {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+  padding: 16px;
+  background: var(--blue);
+  border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
+  border-radius: var(--radius-l);
+  box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.7);
+}
+
+.board__row {
+  display: flex;
+  gap: var(--gap);
+}
+
+.cell {
+  width: var(--cell-size);
+  height: var(--cell-size);
+  flex: 1 1 0;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: var(--radius-s);
+  font-family: inherit;
+  font-weight: 700;
+  font-size: clamp(0.85rem, 2.6vw, 1.05rem);
+  padding: 0;
+  position: relative;
+  transition:
+    transform 0.15s ease,
+    filter 0.15s ease;
+}
+
+.cell[data-state="closed"],
+.cell[data-state="flag"] {
+  background: var(--blue-soft);
+  box-shadow:
+    inset 2px 2px 0 color-mix(in srgb, var(--cream) 18%, transparent),
+    inset -2px -2px 0 rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+}
+
+.cell[data-state="closed"]:hover,
+.cell[data-state="flag"]:hover {
+  filter: brightness(1.15);
+  transform: translateY(-1px);
+}
+
+.cell[data-state="closed"]:active,
+.cell[data-state="flag"]:active {
+  transform: translateY(0) scale(0.95);
+}
+
+.cell[data-state="open"],
+.cell[data-state="mine"],
+.cell[data-state="mine-exploded"] {
+  background: var(--cream-dim);
+  color: var(--navy);
+  cursor: default;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--navy) 12%, transparent);
+}
+
+.cell[data-count="1"] {
+  color: var(--blue);
+}
+.cell[data-count="2"] {
+  color: color-mix(in srgb, var(--blue) 60%, var(--navy));
+}
+.cell[data-count="3"] {
+  color: var(--pink);
+}
+.cell[data-count="4"] {
+  color: color-mix(in srgb, var(--pink) 65%, var(--navy));
+}
+.cell[data-count="5"] {
+  color: color-mix(in srgb, var(--pink) 80%, var(--blue));
+}
+.cell[data-count="6"] {
+  color: color-mix(in srgb, var(--blue) 40%, var(--navy));
+}
+.cell[data-count="7"] {
+  color: var(--navy);
+}
+.cell[data-count="8"] {
+  color: color-mix(in srgb, var(--navy) 70%, var(--pink));
+}
+
+.cell[data-state="flag"]::before {
+  content: "";
+  width: 55%;
+  height: 55%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c51f5d' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.cell[data-state="mine"]::before {
+  content: "";
+  width: 60%;
+  height: 60%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23141d26' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='13' r='9'/%3E%3Cpath d='M14.35 4.65 16.3 2.7a2.41 2.41 0 0 1 3.4 0l1.6 1.6a2.4 2.4 0 0 1 0 3.4l-1.95 1.95'/%3E%3Cpath d='m22 2-1.5 1.5'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.cell[data-state="mine-exploded"] {
+  background: var(--pink);
+}
+
+.cell[data-state="mine-exploded"]::before {
+  content: "";
+  width: 60%;
+  height: 60%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23e2e2d2' stroke='%23e2e2d2' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+}

--- a/FedorchenkoDaria/styles.css
+++ b/FedorchenkoDaria/styles.css
@@ -158,7 +158,8 @@ body {
 }
 
 .cell[data-state="closed"],
-.cell[data-state="flag"] {
+.cell[data-state="flag-safe"],
+.cell[data-state="flag-mine"] {
   background: var(--blue-soft);
   box-shadow:
     inset 2px 2px 0 color-mix(in srgb, var(--cream) 18%, transparent),
@@ -167,13 +168,15 @@ body {
 }
 
 .cell[data-state="closed"]:hover,
-.cell[data-state="flag"]:hover {
+.cell[data-state="flag-safe"]:hover,
+.cell[data-state="flag-mine"]:hover {
   filter: brightness(1.15);
   transform: translateY(-1px);
 }
 
 .cell[data-state="closed"]:active,
-.cell[data-state="flag"]:active {
+.cell[data-state="flag-safe"]:active,
+.cell[data-state="flag-mine"]:active {
   transform: translateY(0) scale(0.95);
 }
 
@@ -218,7 +221,8 @@ body {
   color: color-mix(in srgb, var(--navy) 70%, var(--pink));
 }
 
-.cell[data-state="flag"]::before,
+.cell[data-state="flag-safe"]::before,
+.cell[data-state="flag-mine"]::before,
 .cell[data-state="mine"]::before,
 .cell[data-state="mine-exploded"]::before {
   content: "";
@@ -227,7 +231,8 @@ body {
   background-position: center;
 }
 
-.cell[data-state="flag"]::before {
+.cell[data-state="flag-safe"]::before,
+.cell[data-state="flag-mine"]::before {
   width: 55%;
   height: 55%;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c51f5d' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528'/%3E%3C/svg%3E");

--- a/FedorchenkoDaria/styles.css
+++ b/FedorchenkoDaria/styles.css
@@ -32,9 +32,10 @@ body {
   justify-content: center;
   padding: 32px 16px;
   background: var(--navy);
-  font-family: "Outfit", system-ui, sans-serif;
+  font-family: Outfit, system-ui, sans-serif;
   color: var(--cream);
 }
+
 .game {
   width: 100%;
   max-width: 520px;
@@ -52,7 +53,7 @@ body {
   background: var(--blue);
   border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
   border-radius: var(--radius-l);
-  box-shadow: 0 12px 30px -14px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 12px 30px -14px rgb(0 0 0 / 60%);
 }
 
 .counter {
@@ -68,18 +69,18 @@ body {
   letter-spacing: 0.04em;
 }
 
-.counter__value {
+.counter-value {
   font-size: 1.1rem;
 }
 
-.counter__icon {
+.counter-icon {
   width: 18px;
   height: 18px;
   flex-shrink: 0;
   stroke: var(--pink);
 }
 
-.counter:last-child .counter__icon {
+.counter:last-child .counter-icon {
   stroke: var(--cream);
 }
 
@@ -102,15 +103,24 @@ body {
 
 .restart-btn:hover {
   background: var(--pink-soft);
+  transform: translateY(-1px);
 }
 
-.restart-btn__icon {
+.restart-btn:active {
+  transform: translateY(0) scale(0.95);
+}
+
+.restart-btn-icon {
   width: 22px;
   height: 22px;
   stroke: var(--cream);
   fill: var(--cream);
   margin-left: 2px;
   transition: transform 0.2s ease;
+}
+
+.restart-btn:hover .restart-btn-icon {
+  transform: scale(1.1);
 }
 
 .board {
@@ -121,10 +131,10 @@ body {
   background: var(--blue);
   border: 1px solid color-mix(in srgb, var(--cream) 12%, transparent);
   border-radius: var(--radius-l);
-  box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.7);
+  box-shadow: 0 20px 40px -20px rgb(0 0 0 / 70%);
 }
 
-.board__row {
+.board-row {
   display: flex;
   gap: var(--gap);
 }
@@ -152,7 +162,7 @@ body {
   background: var(--blue-soft);
   box-shadow:
     inset 2px 2px 0 color-mix(in srgb, var(--cream) 18%, transparent),
-    inset -2px -2px 0 rgba(0, 0, 0, 0.35);
+    inset -2px -2px 0 rgb(0 0 0 / 35%);
   cursor: pointer;
 }
 
@@ -179,46 +189,54 @@ body {
 .cell[data-count="1"] {
   color: var(--blue);
 }
+
 .cell[data-count="2"] {
   color: color-mix(in srgb, var(--blue) 60%, var(--navy));
 }
+
 .cell[data-count="3"] {
   color: var(--pink);
 }
+
 .cell[data-count="4"] {
   color: color-mix(in srgb, var(--pink) 65%, var(--navy));
 }
+
 .cell[data-count="5"] {
   color: color-mix(in srgb, var(--pink) 80%, var(--blue));
 }
+
 .cell[data-count="6"] {
   color: color-mix(in srgb, var(--blue) 40%, var(--navy));
 }
+
 .cell[data-count="7"] {
   color: var(--navy);
 }
+
 .cell[data-count="8"] {
   color: color-mix(in srgb, var(--navy) 70%, var(--pink));
 }
 
-.cell[data-state="flag"]::before {
+.cell[data-state="flag"]::before,
+.cell[data-state="mine"]::before,
+.cell[data-state="mine-exploded"]::before {
   content: "";
-  width: 55%;
-  height: 55%;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c51f5d' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528'/%3E%3C/svg%3E");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
 }
 
+.cell[data-state="flag"]::before {
+  width: 55%;
+  height: 55%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c51f5d' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 22V4a1 1 0 0 1 .4-.8A6 6 0 0 1 8 2c3 0 5 2 7.333 2q2 0 3.067-.8A1 1 0 0 1 20 4v10a1 1 0 0 1-.4.8A6 6 0 0 1 16 16c-3 0-5-2-8-2a6 6 0 0 0-4 1.528'/%3E%3C/svg%3E");
+}
+
 .cell[data-state="mine"]::before {
-  content: "";
   width: 60%;
   height: 60%;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23141d26' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='13' r='9'/%3E%3Cpath d='M14.35 4.65 16.3 2.7a2.41 2.41 0 0 1 3.4 0l1.6 1.6a2.4 2.4 0 0 1 0 3.4l-1.95 1.95'/%3E%3Cpath d='m22 2-1.5 1.5'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
 }
 
 .cell[data-state="mine-exploded"] {
@@ -226,11 +244,7 @@ body {
 }
 
 .cell[data-state="mine-exploded"]::before {
-  content: "";
   width: 60%;
   height: 60%;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23e2e2d2' stroke='%23e2e2d2' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
 }


### PR DESCRIPTION
Lab 1: Minesweeper UI Layout

## Summary of Changes:

- Added semantic HTML structure (index.html) with header controls and game board.

- Implemented CSS styling (styles.css) featuring a flexible board layout and custom colors.

- Styled all cell states: closed, open (1-8 numbers), flag, mine, and exploded mine.

- Made the interface responsive and accessible.

## Screenshots

<img width="629" height="566" alt="image" src="https://github.com/user-attachments/assets/a6451bc4-f391-47d1-90cf-04e6a39783d3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Ukrainian-language Minesweeper game page.
  * Added a six-row game board displaying open, closed, flagged, numbered, and mined cells.
  * Added flag and time counters to the game header.
  * Added a restart button for resetting the game.
  * Added visual styling for cell states, mine indicators, number colors, hover effects, and responsive game layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->